### PR TITLE
Add task update command to CLI

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -51,6 +51,22 @@ def cmd_delete(args: argparse.Namespace, manager) -> None:
     print(f"Deleted task [{args.id}].")
 
 
+def cmd_update(args: argparse.Namespace, manager) -> None:
+    """Update a task's title, description, or status."""
+    status = TaskStatus(args.status) if args.status else None
+    try:
+        task = manager.update_task(
+            args.id,
+            title=args.title or None,
+            description=args.description,
+            status=status,
+        )
+    except TaskNotFoundError:
+        print(f"Error: task {args.id} not found.")
+        return
+    print(f"Updated task [{task.id}]: {task.title}")
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -92,6 +108,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_delete = sub.add_parser("delete", help="Delete a task")
     p_delete.add_argument("id", type=int, help="Task ID")
 
+    # update
+    p_update = sub.add_parser("update", help="Update a task")
+    p_update.add_argument("id", type=int, help="Task ID")
+    p_update.add_argument("--title", "-t", default="", help="New title")
+    p_update.add_argument("--description", "-d", default=None, help="New description")
+    p_update.add_argument(
+        "--status",
+        choices=[s.value for s in TaskStatus],
+        help="New status",
+    )
+
     return parser
 
 
@@ -112,6 +139,7 @@ def main(argv=None) -> None:
         "add": cmd_add,
         "complete": cmd_complete,
         "delete": cmd_delete,
+        "update": cmd_update,
     }
     handlers[args.command](args, manager)
 

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -191,3 +191,49 @@ def test_cli_delete_missing_id_prints_error(store, capsys):
     main(["--file", str(store), "delete", "99"])
     out = capsys.readouterr().out
     assert "not found" in out.lower() or "error" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI — update
+# ---------------------------------------------------------------------------
+
+
+def test_cli_update_changes_title_description_and_status(store):
+    main(["--file", str(store), "add", "Draft task"])
+    main(
+        [
+            "--file",
+            str(store),
+            "update",
+            "1",
+            "--title",
+            "Published task",
+            "--description",
+            "Ready to ship",
+            "--status",
+            "in_progress",
+        ]
+    )
+
+    loaded = load(store)
+    task = loaded.get_task(1)
+    assert task.title == "Published task"
+    assert task.description == "Ready to ship"
+    assert task.status == TaskStatus.IN_PROGRESS
+
+
+def test_cli_update_prints_confirmation(store, capsys):
+    main(["--file", str(store), "add", "Write draft"])
+    capsys.readouterr()
+
+    main(["--file", str(store), "update", "1", "--title", "Write final copy"])
+    out = capsys.readouterr().out
+
+    assert "Updated" in out
+    assert "Write final copy" in out
+
+
+def test_cli_update_missing_id_prints_error(store, capsys):
+    main(["--file", str(store), "update", "42", "--title", "Ghost task"])
+    out = capsys.readouterr().out
+    assert "not found" in out.lower() or "error" in out.lower()


### PR DESCRIPTION
**TL;DR:** Adds the missing `task update` CLI subcommand so users can update a task's title, description, and/or status — all 3 previously-failing tests now pass.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `update_task()` was already in the manager layer | `task_manager.py:58` |
| 🟢 | All 38 tests pass after wiring up the CLI command | `task_cli.py` |
| ℹ️ | Omitting `--description` preserves the existing value (no-op) | `task_cli.py:cmd_update` |

<details>
<summary>Implementation details</summary>

Added to `task_cli.py`:
- `cmd_update()` handler that accepts `--title`, `--description`, `--status`
- `update` subparser registered in `build_parser()`
- Handler wired into the `handlers` dispatch dict in `main()`

Usage:
```
task --file tasks.json update 1 --title "New title" --status in_progress
```
</details>