### PR TITLE
Add clear-completed command to task CLI

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -51,6 +51,12 @@ def cmd_delete(args: argparse.Namespace, manager) -> None:
     print(f"Deleted task [{args.id}].")
 
 
+def cmd_clear_completed(args: argparse.Namespace, manager) -> None:
+    """Remove all completed tasks."""
+    count = manager.clear_completed()
+    print(f"Cleared {count} completed task(s).")
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -92,6 +98,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_delete = sub.add_parser("delete", help="Delete a task")
     p_delete.add_argument("id", type=int, help="Task ID")
 
+    # clear-completed
+    sub.add_parser("clear-completed", help="Remove all completed tasks")
+
     return parser
 
 
@@ -112,6 +121,7 @@ def main(argv=None) -> None:
         "add": cmd_add,
         "complete": cmd_complete,
         "delete": cmd_delete,
+        "clear-completed": cmd_clear_completed,
     }
     handlers[args.command](args, manager)
 

--- a/task_manager.py
+++ b/task_manager.py
@@ -82,3 +82,10 @@ class TaskManager:
         if task_id not in self._tasks:
             raise TaskNotFoundError(task_id)
         del self._tasks[task_id]
+
+    def clear_completed(self) -> int:
+        """Remove all DONE tasks and return the number removed."""
+        done_ids = [tid for tid, t in self._tasks.items() if t.status == TaskStatus.DONE]
+        for tid in done_ids:
+            del self._tasks[tid]
+        return len(done_ids)

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -191,3 +191,40 @@ def test_cli_delete_missing_id_prints_error(store, capsys):
     main(["--file", str(store), "delete", "99"])
     out = capsys.readouterr().out
     assert "not found" in out.lower() or "error" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI — clear-completed
+# ---------------------------------------------------------------------------
+
+
+def test_cli_clear_completed_removes_only_done_tasks(store):
+    main(["--file", str(store), "add", "Keep me"])
+    main(["--file", str(store), "add", "Remove me"])
+    main(["--file", str(store), "complete", "2"])
+
+    main(["--file", str(store), "clear-completed"])
+
+    loaded = load(store)
+    tasks = loaded.list_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].title == "Keep me"
+
+
+def test_cli_clear_completed_prints_count(store, capsys):
+    main(["--file", str(store), "add", "Keep me"])
+    main(["--file", str(store), "add", "Remove me"])
+    main(["--file", str(store), "complete", "2"])
+    capsys.readouterr()
+
+    main(["--file", str(store), "clear-completed"])
+    out = capsys.readouterr().out
+
+    assert "Cleared" in out
+    assert "1" in out
+
+
+def test_cli_clear_completed_handles_empty_store(store, capsys):
+    main(["--file", str(store), "clear-completed"])
+    out = capsys.readouterr().out
+    assert "0" in out


### PR DESCRIPTION
**TL;DR:** Adds a `task clear-completed` command that removes all DONE tasks from the store and prints a confirmation count.

## Findings

| | Finding | Location |
|---|---------|----------|
| 🟢 | `clear_completed()` correctly collects IDs before deletion to avoid mutation-during-iteration | `task_manager.py:88-90` |
| 🟢 | All 3 new `clear-completed` CLI tests pass (removes only done, prints count, handles empty) | `test_task_cli.py` |
| 🟢 | Full test suite passes — 38 tests, 0 failures | `test_task_cli.py`, `test_task_manager.py` |
| ℹ️ | `cmd_clear_completed` does not need error handling (no failure cases) — intentionally simple | `task_cli.py:54` |

<details>
<summary>Changes</summary>

- `task_manager.py`: Added `clear_completed() -> int` method
- `task_cli.py`: Added `cmd_clear_completed` handler, `clear-completed` subparser, and dispatch entry
- All existing tests continue to pass (38 total)

</details>