### PR TITLE
feat: add tag and search filtering to TaskManager and CLI

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -14,20 +14,22 @@ from task_store import DEFAULT_PATH, load, save
 
 
 def cmd_list(args: argparse.Namespace, manager) -> None:
-    """List tasks, optionally filtered by status."""
+    """List tasks, optionally filtered by status, tag, or search."""
     status = TaskStatus(args.status) if args.status else None
-    tasks = manager.list_tasks(status=status)
+    tasks = manager.list_tasks(status=status, tag=args.tag, search=args.search)
     if not tasks:
         print("No tasks found.")
         return
     for task in tasks:
         desc = f"  {task.description}" if task.description else ""
-        print(f"[{task.id}] [{task.status.value}] {task.title}{desc}")
+        tags = (" " + " ".join(f"#{t}" for t in task.tags)) if task.tags else ""
+        print(f"[{task.id}] [{task.status.value}] {task.title}{desc}{tags}")
 
 
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
-    task = manager.add_task(args.title, description=args.description or "")
+    tags = args.tag if args.tag else []
+    task = manager.add_task(args.title, description=args.description or "", tags=tags)
     print(f"Added task [{task.id}]: {task.title}")
 
 
@@ -78,11 +80,14 @@ def build_parser() -> argparse.ArgumentParser:
         choices=[s.value for s in TaskStatus],
         help="Filter by status",
     )
+    p_list.add_argument("--tag", default=None, help="Filter by tag")
+    p_list.add_argument("--search", default=None, help="Search title and description")
 
     # add
     p_add = sub.add_parser("add", help="Add a new task")
     p_add.add_argument("title", help="Task title")
     p_add.add_argument("--description", "-d", default="", help="Optional description")
+    p_add.add_argument("--tag", action="append", dest="tag", help="Add a tag (repeatable)")
 
     # complete
     p_complete = sub.add_parser("complete", help="Mark a task as done")

--- a/task_cli.py
+++ b/task_cli.py
@@ -22,7 +22,7 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
         return
     for task in tasks:
         desc = f"  {task.description}" if task.description else ""
-        tags = (" " + " ".join(f"#{t}" for t in task.tags)) if task.tags else ""
+        tags = (" " + " ".join(f"#{t}" for t in sorted(task.tags))) if task.tags else ""
         print(f"[{task.id}] [{task.status.value}] {task.title}{desc}{tags}")
 
 

--- a/task_manager.py
+++ b/task_manager.py
@@ -56,7 +56,7 @@ class TaskManager:
         search: Optional[str] = None,
     ) -> list[Task]:
         """Return all tasks, optionally filtered by *status*, *tag*, or *search*."""
-        tasks = list(self._tasks.values())
+        tasks = sorted(self._tasks.values(), key=lambda t: t.id)
         if status is not None:
             tasks = [t for t in tasks if t.status == status]
         if tag is not None:

--- a/task_manager.py
+++ b/task_manager.py
@@ -1,6 +1,6 @@
 """In-memory task manager library."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
@@ -21,6 +21,7 @@ class Task:
     title: str
     description: str = ""
     status: TaskStatus = TaskStatus.PENDING
+    tags: list[str] = field(default_factory=list)
 
 
 class TaskNotFoundError(KeyError):
@@ -35,9 +36,9 @@ class TaskManager:
         self._tasks: dict[int, Task] = {}
         self._next_id: int = 1
 
-    def add_task(self, title: str, description: str = "") -> Task:
+    def add_task(self, title: str, description: str = "", tags: Optional[list[str]] = None) -> Task:
         """Create and store a new task, returning it."""
-        task = Task(id=self._next_id, title=title, description=description)
+        task = Task(id=self._next_id, title=title, description=description, tags=list(tags or []))
         self._tasks[self._next_id] = task
         self._next_id += 1
         return task
@@ -48,11 +49,21 @@ class TaskManager:
             raise TaskNotFoundError(task_id)
         return self._tasks[task_id]
 
-    def list_tasks(self, status: Optional[TaskStatus] = None) -> list[Task]:
-        """Return all tasks, optionally filtered by *status*."""
+    def list_tasks(
+        self,
+        status: Optional[TaskStatus] = None,
+        tag: Optional[str] = None,
+        search: Optional[str] = None,
+    ) -> list[Task]:
+        """Return all tasks, optionally filtered by *status*, *tag*, or *search*."""
         tasks = list(self._tasks.values())
         if status is not None:
             tasks = [t for t in tasks if t.status == status]
+        if tag is not None:
+            tasks = [t for t in tasks if tag in t.tags]
+        if search is not None:
+            query = search.lower()
+            tasks = [t for t in tasks if query in t.title.lower() or query in t.description.lower()]
         return tasks
 
     def update_task(

--- a/task_store.py
+++ b/task_store.py
@@ -20,6 +20,7 @@ def load(path: Path = DEFAULT_PATH) -> TaskManager:
             title=item["title"],
             description=item.get("description", ""),
             status=TaskStatus(item["status"]),
+            tags=item.get("tags", []),
         )
         manager._tasks[task.id] = task
     manager._next_id = data.get(
@@ -39,6 +40,7 @@ def save(manager: TaskManager, path: Path = DEFAULT_PATH) -> None:
                 "title": t.title,
                 "description": t.description,
                 "status": t.status.value,
+                "tags": t.tags,
             }
             for t in manager._tasks.values()
         ],

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -62,6 +62,15 @@ def test_save_persists_description(store):
     assert loaded.list_tasks()[0].description == "Look up references"
 
 
+def test_save_persists_tags(store):
+    manager = TaskManager()
+    manager.add_task("Plan trip", tags=["personal", "travel"])
+    save(manager, store)
+
+    loaded = load(store)
+    assert getattr(loaded.list_tasks()[0], "tags", None) == ["personal", "travel"]
+
+
 def test_save_preserves_next_id(store):
     """IDs must not restart after a round-trip (avoids collisions)."""
     manager = TaskManager()
@@ -97,6 +106,13 @@ def test_cli_add_with_description(store):
     loaded = load(store)
     task = loaded.list_tasks()[0]
     assert task.description == "Check docs"
+
+
+def test_cli_add_with_tags(store):
+    main(["--file", str(store), "add", "Plan trip", "--tag", "personal", "--tag", "travel"])
+    loaded = load(store)
+    task = loaded.list_tasks()[0]
+    assert task.tags == ["personal", "travel"]
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +154,50 @@ def test_cli_list_filter_done(store, capsys):
     out = capsys.readouterr().out
     assert "Done task" in out
     assert "Pending task" not in out
+
+
+def test_cli_list_filter_tag(store, capsys):
+    main(["--file", str(store), "add", "Rotate keys", "--tag", "ops"])
+    main(["--file", str(store), "add", "Buy milk", "--tag", "home"])
+    capsys.readouterr()
+
+    main(["--file", str(store), "list", "--tag", "ops"])
+    out = capsys.readouterr().out
+
+    assert "Rotate keys" in out
+    assert "Buy milk" not in out
+
+
+def test_cli_list_search_matches_description(store, capsys):
+    main(
+        [
+            "--file",
+            str(store),
+            "add",
+            "Draft roadmap",
+            "--description",
+            "Plan Q3 milestones",
+        ]
+    )
+    main(["--file", str(store), "add", "Buy milk", "--description", "Groceries for home"])
+    capsys.readouterr()
+
+    main(["--file", str(store), "list", "--search", "milestones"])
+    out = capsys.readouterr().out
+
+    assert "Draft roadmap" in out
+    assert "Buy milk" not in out
+
+
+def test_cli_list_shows_tags(store, capsys):
+    main(["--file", str(store), "add", "Rotate keys", "--tag", "ops", "--tag", "urgent"])
+    capsys.readouterr()
+
+    main(["--file", str(store), "list"])
+    out = capsys.readouterr().out
+
+    assert "#ops" in out
+    assert "#urgent" in out
 
 
 # ---------------------------------------------------------------------------

--- a/test_task_manager.py
+++ b/test_task_manager.py
@@ -34,6 +34,11 @@ def test_add_task_stores_description(manager):
     assert task.description == "Cover all edge cases"
 
 
+def test_add_task_stores_tags(manager):
+    task = manager.add_task("Plan trip", tags=["personal", "travel"])
+    assert task.tags == ["personal", "travel"]
+
+
 # ---------------------------------------------------------------------------
 # get_task
 # ---------------------------------------------------------------------------
@@ -77,6 +82,23 @@ def test_list_tasks_filter_by_status(manager):
     assert t2 not in pending
     assert t2 in done
     assert t1 not in done
+
+
+def test_list_tasks_can_filter_by_tag(manager):
+    tagged = manager.add_task("Rotate keys", tags=["ops"])
+    manager.add_task("Buy milk", tags=["home"])
+
+    matches = manager.list_tasks(tag="ops")
+
+    assert matches == [tagged]
+
+
+def test_list_tasks_can_search_title_and_description(manager):
+    roadmap = manager.add_task("Draft roadmap", description="Plan Q3 milestones")
+    manager.add_task("Buy milk", description="Groceries for home")
+
+    assert manager.list_tasks(search="road") == [roadmap]
+    assert manager.list_tasks(search="milestones") == [roadmap]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**TL;DR:** Adds `tags` support to `Task` and `TaskManager`, with CLI `--tag`/`--search` filters and JSON persistence. All 43 tests pass.

| | Finding | Location |
|---|---------|----------|
| 🟢 | All 43 tests pass with new tag/search coverage | `test_task_cli.py`, `test_task_manager.py` |
| 🟢 | Tag output is sorted alphabetically for deterministic display | `task_cli.py:25` |
| 🟢 | `list_tasks()` returns tasks sorted by ID for stable ordering | `task_manager.py:59` |
| 🟢 | Tags persisted and loaded correctly via `task_store.py` | `task_store.py:23,42` |
| ℹ️ | `--tag` on `add` uses `action="append"` — multiple tags supported | `task_cli.py:90` |