### PR TITLE
docs: add title/body maintenance scenario to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo exists solely for e2e testing. PRs opened here exercise the PR Rocket 
 
 ## Test Scenarios
 
+- Title/body maintenance scenario for PR Rocket metadata updates
 - Open a PR with a failing lint/test → verify `fix_ci` feature
 - Open a PR with merge conflicts → verify `fix_conflicts` feature
 - Use `/rocket` commands in PR comments


### PR DESCRIPTION
**TL;DR:** Adds one line to `README.md` documenting the title/body maintenance test scenario for PR Rocket. No code or logic changes.

| | Finding | Location |
|---|---------|----------|
| 🟢 | README documents the PR Rocket metadata-maintenance test scenario | `README.md:11` |

<details>
<summary>Details</summary>

### What changed
- Added a bullet to the `## Test Scenarios` section of `README.md` describing the title/body maintenance scenario for PR Rocket metadata updates.

### Why
- Explicitly documents and exercises PR Rocket's ability to maintain PR titles and descriptions for documentation-only changes.

### Testing notes
- Documentation-only change; no code or tests were modified.
- No breaking changes.

</details>