### PR TITLE
docs: add test scenario for docs-only PR metadata refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo exists solely for e2e testing. PRs opened here exercise the PR Rocket 
 - Open a PR with merge conflicts → verify `fix_conflicts` feature
 - Use `/rocket` commands in PR comments
 - Test the control panel toggle flow
+- Refresh PR metadata for docs-only changes and keep the summary concise
 
 ## Build Exercise
 


### PR DESCRIPTION
**TL;DR:** Adds a new e2e test scenario to README to verify PR Rocket handles docs-only PRs by refreshing metadata and keeping the summary concise.

## Findings

| | Finding | Location |
|---|---------|----------|
| 🟢 | All 37 tests pass; no CI issues | `test_*.py` |
| 🟢 | Minimal, focused docs-only change | `README.md:15` |
| ℹ️ | PR title "stuff" and body "some updates" were vague — updated to be descriptive | `PR metadata` |