### PR TITLE
feat: add reopen command to move completed tasks back to pending

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ python task_cli.py list --status pending
 # Complete a task
 python task_cli.py complete 1
 
+# Re-open a completed task
+python task_cli.py reopen 1
+
 # Delete a task
 python task_cli.py delete 2
 

--- a/task_cli.py
+++ b/task_cli.py
@@ -41,6 +41,16 @@ def cmd_complete(args: argparse.Namespace, manager) -> None:
     print(f"Completed task [{task.id}]: {task.title}")
 
 
+def cmd_reopen(args: argparse.Namespace, manager) -> None:
+    """Mark a task as pending (reopen it)."""
+    try:
+        task = manager.reopen_task(args.id)
+    except TaskNotFoundError:
+        print(f"Error: task {args.id} not found.")
+        return
+    print(f"Reopened task [{task.id}]: {task.title}")
+
+
 def cmd_delete(args: argparse.Namespace, manager) -> None:
     """Delete a task."""
     try:
@@ -88,6 +98,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_complete = sub.add_parser("complete", help="Mark a task as done")
     p_complete.add_argument("id", type=int, help="Task ID")
 
+    # reopen
+    p_reopen = sub.add_parser("reopen", help="Reopen a completed task")
+    p_reopen.add_argument("id", type=int, help="Task ID")
+
     # delete
     p_delete = sub.add_parser("delete", help="Delete a task")
     p_delete.add_argument("id", type=int, help="Task ID")
@@ -111,6 +125,7 @@ def main(argv=None) -> None:
         "list": cmd_list,
         "add": cmd_add,
         "complete": cmd_complete,
+        "reopen": cmd_reopen,
         "delete": cmd_delete,
     }
     handlers[args.command](args, manager)

--- a/task_manager.py
+++ b/task_manager.py
@@ -77,6 +77,10 @@ class TaskManager:
         """Mark *task_id* as DONE and return it."""
         return self.update_task(task_id, status=TaskStatus.DONE)
 
+    def reopen_task(self, task_id: int) -> Task:
+        """Mark *task_id* as PENDING and return it."""
+        return self.update_task(task_id, status=TaskStatus.PENDING)
+
     def delete_task(self, task_id: int) -> None:
         """Remove *task_id* from the store."""
         if task_id not in self._tasks:

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -166,6 +166,24 @@ def test_cli_complete_missing_id_prints_error(store, capsys):
     assert "not found" in out.lower() or "error" in out.lower()
 
 
+def test_cli_reopen_prints_confirmation(store, capsys):
+    main(["--file", str(store), "add", "Follow up"])
+    main(["--file", str(store), "complete", "1"])
+    capsys.readouterr()
+    main(["--file", str(store), "reopen", "1"])
+    out = capsys.readouterr().out
+    assert "Reopened" in out
+    assert "Follow up" in out
+
+
+def test_cli_reopen_persists_status(store):
+    main(["--file", str(store), "add", "Follow up"])
+    main(["--file", str(store), "complete", "1"])
+    main(["--file", str(store), "reopen", "1"])
+    loaded = load(store)
+    assert loaded.get_task(1).status == TaskStatus.PENDING
+
+
 # ---------------------------------------------------------------------------
 # CLI — delete
 # ---------------------------------------------------------------------------

--- a/test_task_manager.py
+++ b/test_task_manager.py
@@ -123,6 +123,13 @@ def test_complete_task_raises_for_missing_id(manager):
         manager.complete_task(99)
 
 
+def test_reopen_task_sets_pending(manager):
+    task = manager.add_task("Follow up")
+    manager.complete_task(task.id)
+    reopened = manager.reopen_task(task.id)
+    assert reopened.status == TaskStatus.PENDING
+
+
 # ---------------------------------------------------------------------------
 # delete_task
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a `reopen` command that moves completed tasks back to pending, mirroring the existing `complete` command pattern end-to-end.

- `task_manager.reopen_task` delegates to `update_task`, consistent with how `complete_task` works
- `reopen` on an already-pending task silently succeeds — consider adding a warning if that matters