### PR TITLE
fix: resolve README merge conflict and keep PR wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo exists solely for e2e testing. PRs opened here exercise the PR Rocket 
 - Open a PR with a failing lint/test → verify `fix_ci` feature
 - Open a PR with merge conflicts → verify `fix_conflicts` feature
 - Use `/rocket` commands in PR comments
-- Test the control panel toggle flow
+- Test the control panel toggle flow from both the PR timeline and control panel comment
 
 ## Build Exercise
 


### PR DESCRIPTION
**TL;DR:** Resolved a `README.md` merge conflict by keeping the PR's intended wording ("from both the PR timeline and control panel comment"). Branch is clean and all 37 tests pass.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Merge conflict resolved cleanly — no conflict markers remain | `README.md:14` |
| 🟢 | All 37 tests pass after merge | `test_*.py` |
| ℹ️ | Doc-only change; no logic or API surface affected | `README.md` |

<details>
<summary>Diff summary</summary>

```diff
-  Test the control panel toggle flow using both slash commands and inline status updates
+  Test the control panel toggle flow from both the PR timeline and control panel comment
```

</details>