### PR TITLE
Add `task count` subcommand with optional status filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ python task_cli.py complete 1
 # Delete a task
 python task_cli.py delete 2
 
+# Count all tasks
+python task_cli.py count
+
+# Count tasks by status
+python task_cli.py count --status done
+
 # Use a custom store file
 python task_cli.py --file my_tasks.json list
 ```

--- a/task_cli.py
+++ b/task_cli.py
@@ -51,6 +51,13 @@ def cmd_delete(args: argparse.Namespace, manager) -> None:
     print(f"Deleted task [{args.id}].")
 
 
+def cmd_count(args: argparse.Namespace, manager) -> None:
+    """Print the number of tasks, optionally filtered by status."""
+    status = TaskStatus(args.status) if args.status else None
+    n = len(manager.list_tasks(status=status))
+    print(f"{n} task{'s' if n != 1 else ''}")
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -92,6 +99,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_delete = sub.add_parser("delete", help="Delete a task")
     p_delete.add_argument("id", type=int, help="Task ID")
 
+    # count
+    p_count = sub.add_parser("count", help="Count tasks")
+    p_count.add_argument(
+        "--status",
+        choices=[s.value for s in TaskStatus],
+        help="Filter by status",
+    )
+
     return parser
 
 
@@ -112,6 +127,7 @@ def main(argv=None) -> None:
         "add": cmd_add,
         "complete": cmd_complete,
         "delete": cmd_delete,
+        "count": cmd_count,
     }
     handlers[args.command](args, manager)
 

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -140,6 +140,28 @@ def test_cli_list_filter_done(store, capsys):
     assert "Pending task" not in out
 
 
+def test_cli_count_empty(store, capsys):
+    main(["--file", str(store), "count"])
+    assert capsys.readouterr().out.strip() == "0 tasks"
+
+
+def test_cli_count_all_tasks(store, capsys):
+    main(["--file", str(store), "add", "Task A"])
+    main(["--file", str(store), "add", "Task B"])
+    capsys.readouterr()
+    main(["--file", str(store), "count"])
+    assert capsys.readouterr().out.strip() == "2 tasks"
+
+
+def test_cli_count_filter_done(store, capsys):
+    main(["--file", str(store), "add", "Pending task"])
+    main(["--file", str(store), "add", "Done task"])
+    main(["--file", str(store), "complete", "2"])
+    capsys.readouterr()
+    main(["--file", str(store), "count", "--status", "done"])
+    assert capsys.readouterr().out.strip() == "1 task"
+
+
 # ---------------------------------------------------------------------------
 # CLI — complete
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**TL;DR:** Adds `task count` (total) and `task count --status <status>` (filtered) with singular/plural output. All 40 tests pass; README updated with usage examples.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `cmd_count` with correct singular/plural (`1 task` / `N tasks`) | `task_cli.py:54-58` |
| 🟢 | `--status` filter mirrors the `list` subcommand pattern | `task_cli.py:103-108` |
| 🟢 | Three count tests: empty, all-tasks, filtered-by-status | `test_task_cli.py` |
| 🟢 | README usage examples for bare `count` and `count --status done` | `README.md:41-46` |
| ℹ️ | 40/40 tests pass, no regressions | all test files |