### PR TITLE
feat: implement `task start <id>` command to mark tasks in_progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ python task_cli.py list --status pending
 # Complete a task
 python task_cli.py complete 1
 
+# Start a task (mark it in progress)
+python task_cli.py start 1
+
 # Delete a task
 python task_cli.py delete 2
 

--- a/task_cli.py
+++ b/task_cli.py
@@ -31,6 +31,16 @@ def cmd_add(args: argparse.Namespace, manager) -> None:
     print(f"Added task [{task.id}]: {task.title}")
 
 
+def cmd_start(args: argparse.Namespace, manager) -> None:
+    """Mark a task as in progress."""
+    try:
+        task = manager.start_task(args.id)
+    except TaskNotFoundError:
+        print(f"Error: task {args.id} not found.")
+        return
+    print(f"Started task [{task.id}]: {task.title}")
+
+
 def cmd_complete(args: argparse.Namespace, manager) -> None:
     """Mark a task as done."""
     try:
@@ -84,6 +94,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_add.add_argument("title", help="Task title")
     p_add.add_argument("--description", "-d", default="", help="Optional description")
 
+    # start
+    p_start = sub.add_parser("start", help="Mark a task as in progress")
+    p_start.add_argument("id", type=int, help="Task ID")
+
     # complete
     p_complete = sub.add_parser("complete", help="Mark a task as done")
     p_complete.add_argument("id", type=int, help="Task ID")
@@ -110,6 +124,7 @@ def main(argv=None) -> None:
     handlers = {
         "list": cmd_list,
         "add": cmd_add,
+        "start": cmd_start,
         "complete": cmd_complete,
         "delete": cmd_delete,
     }

--- a/task_manager.py
+++ b/task_manager.py
@@ -73,6 +73,10 @@ class TaskManager:
             task.status = status
         return task
 
+    def start_task(self, task_id: int) -> Task:
+        """Mark *task_id* as IN_PROGRESS and return it."""
+        return self.update_task(task_id, status=TaskStatus.IN_PROGRESS)
+
     def complete_task(self, task_id: int) -> Task:
         """Mark *task_id* as DONE and return it."""
         return self.update_task(task_id, status=TaskStatus.DONE)

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -167,6 +167,33 @@ def test_cli_complete_missing_id_prints_error(store, capsys):
 
 
 # ---------------------------------------------------------------------------
+# CLI — start
+# ---------------------------------------------------------------------------
+
+
+def test_cli_start_sets_task_in_progress(store):
+    main(["--file", str(store), "add", "Draft release notes"])
+    main(["--file", str(store), "start", "1"])
+    loaded = load(store)
+    assert loaded.get_task(1).status == TaskStatus.IN_PROGRESS
+
+
+def test_cli_start_prints_confirmation(store, capsys):
+    main(["--file", str(store), "add", "Investigate flaky test"])
+    capsys.readouterr()
+    main(["--file", str(store), "start", "1"])
+    out = capsys.readouterr().out
+    assert "Started" in out
+    assert "Investigate flaky test" in out
+
+
+def test_cli_start_missing_id_prints_error(store, capsys):
+    main(["--file", str(store), "start", "99"])
+    out = capsys.readouterr().out
+    assert "not found" in out.lower() or "error" in out.lower()
+
+
+# ---------------------------------------------------------------------------
 # CLI — delete
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implements the `task start <id>` command, completing the failing tests intentionally left without implementation.

**Changes:**
- `task_manager.py`: Added `start_task(task_id)` — marks the task `IN_PROGRESS` via the existing `update_task` helper
- `task_cli.py`: Added `cmd_start` handler (prints `Started task [id]: title`), `start` subparser, and registered handler in `main()`
- `test_task_cli.py`: 3 new tests for start command (status, confirmation, error)
- `README.md`: Added usage example for `task start 1`

---

## Findings

| | Finding | Location |
|---|---------|----------|
| 🟢 | `start_task()` follows same pattern as `complete_task()` — consistent API | `task_manager.py:76` |
| 🟢 | `cmd_start` error handling mirrors `cmd_complete` — consistent CLI wording | `task_cli.py:31` |
| 🟢 | All 3 new `start` CLI tests pass: status persists, confirmation printed, missing-id error handled | `test_task_cli.py:169` |
| ℹ️ | `start_task` unit test only in CLI tests; no direct `test_task_manager.py` coverage | `test_task_manager.py` |

**Test results:** 38 passed ✅