### PR TITLE
feat: sort task list pending → in_progress → done

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ python task_cli.py add "Write report" --description "Q2 summary"
 # List all tasks
 python task_cli.py list
 
+# List all tasks with active work first
+# (pending, then in_progress, then done)
+python task_cli.py list
+
 # Filter by status: pending, in_progress, done
 python task_cli.py list --status pending
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ Step 2 adds a small CLI and JSON persistence on top of that task manager.
 python task_cli.py add "Buy milk"
 python task_cli.py add "Write report" --description "Q2 summary"
 
-# List all tasks
-python task_cli.py list
-
-# List all tasks with active work first
-# (pending, then in_progress, then done)
+# List all tasks (pending first, then in_progress, then done)
 python task_cli.py list
 
 # Filter by status: pending, in_progress, done

--- a/task_manager.py
+++ b/task_manager.py
@@ -49,10 +49,17 @@ class TaskManager:
         return self._tasks[task_id]
 
     def list_tasks(self, status: Optional[TaskStatus] = None) -> list[Task]:
-        """Return all tasks, optionally filtered by *status*."""
+        """Return tasks ordered pending → in_progress → done, optionally filtered by *status*."""
         tasks = list(self._tasks.values())
         if status is not None:
             tasks = [t for t in tasks if t.status == status]
+        else:
+            _status_order = {
+                TaskStatus.PENDING: 0,
+                TaskStatus.IN_PROGRESS: 1,
+                TaskStatus.DONE: 2,
+            }
+            tasks.sort(key=lambda t: (_status_order[t.status], t.id))
         return tasks
 
     def update_task(

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -140,6 +140,25 @@ def test_cli_list_filter_done(store, capsys):
     assert "Pending task" not in out
 
 
+def test_cli_list_orders_active_work_before_done(store, capsys):
+    manager = TaskManager()
+    first = manager.add_task("First pending")
+    second = manager.add_task("Second pending")
+    third = manager.add_task("Work in progress")
+    done = manager.add_task("Already done")
+    manager.update_task(third.id, status=TaskStatus.IN_PROGRESS)
+    manager.complete_task(done.id)
+    save(manager, store)
+
+    main(["--file", str(store), "list"])
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+
+    assert "First pending" in lines[0]
+    assert "Work in progress" in lines[1]
+    assert "Second pending" in lines[2]
+    assert "Already done" in lines[3]
+
+
 # ---------------------------------------------------------------------------
 # CLI — complete
 # ---------------------------------------------------------------------------

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -154,8 +154,8 @@ def test_cli_list_orders_active_work_before_done(store, capsys):
     lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
 
     assert "First pending" in lines[0]
-    assert "Work in progress" in lines[1]
-    assert "Second pending" in lines[2]
+    assert "Second pending" in lines[1]
+    assert "Work in progress" in lines[2]
     assert "Already done" in lines[3]
 
 

--- a/test_task_manager.py
+++ b/test_task_manager.py
@@ -90,7 +90,7 @@ def test_list_tasks_orders_active_work_before_done(manager):
 
     ordered = manager.list_tasks()
 
-    assert [task.id for task in ordered] == [first.id, third.id, second.id, done.id]
+    assert [task.id for task in ordered] == [first.id, second.id, third.id, done.id]
 
 
 # ---------------------------------------------------------------------------

--- a/test_task_manager.py
+++ b/test_task_manager.py
@@ -79,6 +79,20 @@ def test_list_tasks_filter_by_status(manager):
     assert t1 not in done
 
 
+def test_list_tasks_orders_active_work_before_done(manager):
+    first = manager.add_task("First pending")
+    second = manager.add_task("Second pending")
+    third = manager.add_task("Work in progress")
+    done = manager.add_task("Already done")
+
+    manager.update_task(third.id, status=TaskStatus.IN_PROGRESS)
+    manager.complete_task(done.id)
+
+    ordered = manager.list_tasks()
+
+    assert [task.id for task in ordered] == [first.id, third.id, second.id, done.id]
+
+
 # ---------------------------------------------------------------------------
 # update_task
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements active-work-first ordering in the task list output. Pending tasks appear first, in-progress second, and completed last; original insertion order is preserved within each bucket.

| | Finding | Location |
|---|---------|----------|
| 🔴 | Test assertions had in_progress before second pending, contradicting the spec | `test_task_manager.py:93`, `test_task_cli.py:157` |
| 🟢 | Sorting only applies to unfiltered queries; `--status` filter results are unaffected | `task_manager.py:51` |
| 🟢 | Sort is stable within each bucket (keyed on task id = insertion order) | `task_manager.py:57` |
| ℹ️ | Duplicate README list example removed | `README.md:32` |

<details>
<summary>Implementation detail</summary>

```python
_status_order = {
    TaskStatus.PENDING: 0,
    TaskStatus.IN_PROGRESS: 1,
    TaskStatus.DONE: 2,
}
tasks.sort(key=lambda t: (_status_order[t.status], t.id))
```
</details>