### PR TITLE
ux: include task title in delete confirmation

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -44,11 +44,11 @@ def cmd_complete(args: argparse.Namespace, manager) -> None:
 def cmd_delete(args: argparse.Namespace, manager) -> None:
     """Delete a task."""
     try:
-        manager.delete_task(args.id)
+        task = manager.delete_task(args.id)
     except TaskNotFoundError:
         print(f"Error: task {args.id} not found.")
         return
-    print(f"Deleted task [{args.id}].")
+    print(f"Deleted task [{task.id}]: {task.title}")
 
 
 # ---------------------------------------------------------------------------

--- a/task_manager.py
+++ b/task_manager.py
@@ -77,8 +77,9 @@ class TaskManager:
         """Mark *task_id* as DONE and return it."""
         return self.update_task(task_id, status=TaskStatus.DONE)
 
-    def delete_task(self, task_id: int) -> None:
-        """Remove *task_id* from the store."""
+    def delete_task(self, task_id: int) -> Task:
+        """Remove *task_id* from the store and return the deleted task."""
         if task_id not in self._tasks:
             raise TaskNotFoundError(task_id)
-        del self._tasks[task_id]
+        task = self._tasks.pop(task_id)
+        return task

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -185,6 +185,7 @@ def test_cli_delete_prints_confirmation(store, capsys):
     out = capsys.readouterr().out
     assert "Deleted" in out
     assert "1" in out
+    assert "Temp task" in out
 
 
 def test_cli_delete_missing_id_prints_error(store, capsys):


### PR DESCRIPTION
**TL;DR:** Delete confirmation now includes both the task ID and title, matching the UX of `add` and `complete`.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `delete_task()` returns the deleted `Task`, consistent with `complete_task()` | `task_manager.py:80` |
| 🟢 | Delete confirmation: `Deleted task [id]: title` — matches add/complete pattern | `task_cli.py:55` |
| 🟢 | New test assertion verifies task title appears in delete output | `test_task_cli.py:188` |
| ℹ️ | All 35 tests pass | `test_task_cli.py`, `test_task_manager.py` |

## Changes
- **`task_manager.py`**: `delete_task()` now pops and returns the `Task` instead of `del`-ing and returning `None`
- **`task_cli.py`**: `cmd_delete()` captures the returned task and prints `Deleted task [{task.id}]: {task.title}`
- **`test_task_cli.py`**: Test asserts task title appears in the delete confirmation output