### PR TITLE
ux: include "done" in task completion confirmation

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -38,7 +38,7 @@ def cmd_complete(args: argparse.Namespace, manager) -> None:
     except TaskNotFoundError:
         print(f"Error: task {args.id} not found.")
         return
-    print(f"Completed task [{task.id}]: {task.title}")
+    print(f"Completed task [{task.id}]: {task.title} — done.")
 
 
 def cmd_delete(args: argparse.Namespace, manager) -> None:

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -151,6 +151,7 @@ def test_cli_complete_prints_confirmation(store, capsys):
     out = capsys.readouterr().out
     assert "Completed" in out
     assert "Deploy app" in out
+    assert "done" in out.lower()
 
 
 def test_cli_complete_persists_status(store):


### PR DESCRIPTION
**TL;DR:** Updates the `complete` command confirmation to say "— done." so the output is unambiguous and consistent with the add/delete style.

## Changes
- `task_cli.py`: `cmd_complete` now prints `Completed task [x]: title — done.`

## Findings

| | Finding | Location |
|---|---------|----------|
| 🟢 | Confirmation message now clearly states task is done | `task_cli.py:37` |
| 🟢 | All 35 tests pass after fix | `test_task_cli.py` |