### PR TITLE
Include description in add task confirmation output

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -28,7 +28,10 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
     task = manager.add_task(args.title, description=args.description or "")
-    print(f"Added task [{task.id}]: {task.title}")
+    if task.description:
+        print(f"Added task [{task.id}]: {task.title} - {task.description}")
+    else:
+        print(f"Added task [{task.id}]: {task.title}")
 
 
 def cmd_complete(args: argparse.Namespace, manager) -> None:

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -80,10 +80,11 @@ def test_save_preserves_next_id(store):
 
 
 def test_cli_add_prints_confirmation(store, capsys):
-    main(["--file", str(store), "add", "Fix bug"])
+    main(["--file", str(store), "add", "Fix bug", "--description", "Handle edge case"])
     out = capsys.readouterr().out
     assert "Fix bug" in out
     assert "Added" in out
+    assert "Handle edge case" in out
 
 
 def test_cli_add_persists_task(store):


### PR DESCRIPTION
`cmd_add` now shows the description in the confirmation message when one is supplied — single line, no parentheses, consistent with the CLI's existing voice.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `cmd_add` confirmation now surfaces description on a single clean line | `task_cli.py:31` |
| ℹ️ | No description? Output unchanged — backward compatible | `task_cli.py:31` |

<details>
<summary>Example output</summary>

```
# With description
$ task add "Fix bug" --description "Handle edge case"
Added task [1]: Fix bug - Handle edge case

# Without description (unchanged)
$ task add "Fix bug"
Added task [1]: Fix bug
```
</details>