### PR TITLE
Add task ID and title to delete confirmation message

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -44,11 +44,11 @@ def cmd_complete(args: argparse.Namespace, manager) -> None:
 def cmd_delete(args: argparse.Namespace, manager) -> None:
     """Delete a task."""
     try:
-        manager.delete_task(args.id)
+        task = manager.delete_task(args.id)
     except TaskNotFoundError:
         print(f"Error: task {args.id} not found.")
         return
-    print(f"Deleted task [{args.id}].")
+    print(f"Deleted task [{task.id}]: {task.title}.")
 
 
 # ---------------------------------------------------------------------------

--- a/task_manager.py
+++ b/task_manager.py
@@ -77,8 +77,9 @@ class TaskManager:
         """Mark *task_id* as DONE and return it."""
         return self.update_task(task_id, status=TaskStatus.DONE)
 
-    def delete_task(self, task_id: int) -> None:
-        """Remove *task_id* from the store."""
+    def delete_task(self, task_id: int) -> "Task":
+        """Remove *task_id* from the store and return the deleted task."""
         if task_id not in self._tasks:
             raise TaskNotFoundError(task_id)
-        del self._tasks[task_id]
+        task = self._tasks.pop(task_id)
+        return task

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -185,6 +185,7 @@ def test_cli_delete_prints_confirmation(store, capsys):
     out = capsys.readouterr().out
     assert "Deleted" in out
     assert "1" in out
+    assert "Temp task" in out
 
 
 def test_cli_delete_missing_id_prints_error(store, capsys):


### PR DESCRIPTION
**TL;DR:** Delete confirmation now prints both the task ID and title (e.g., `Deleted task [1]: My task.`), consistent with the existing `complete_task` pattern.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `delete_task` returns deleted task, consistent with `complete_task` pattern | `task_manager.py:80` |
| 🟢 | Delete confirmation includes task ID and title | `task_cli.py:46` |
| ℹ️ | All 35 tests pass | `test_task_cli.py, test_task_manager.py` |

## Changes

- **`task_manager.py`**: `delete_task` now returns the deleted `Task` (using `dict.pop`), matching the pattern of `complete_task`
- **`task_cli.py`**: `cmd_delete` captures the returned task and prints `Deleted task [{task.id}]: {task.title}.`