### PR TITLE
Include done wording in complete confirmation

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -38,7 +38,7 @@ def cmd_complete(args: argparse.Namespace, manager) -> None:
     except TaskNotFoundError:
         print(f"Error: task {args.id} not found.")
         return
-    print(f"Completed task [{task.id}]: {task.title}")
+    print(f"Completed task [{task.id}] '{task.title}' — done.")
 
 
 def cmd_delete(args: argparse.Namespace, manager) -> None:

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -152,6 +152,13 @@ def test_cli_complete_prints_confirmation(store, capsys):
     assert "Completed" in out
     assert "Deploy app" in out
     assert "done" in out.lower()
+    # Confirmation must be a single line containing both the task ID and title
+    confirmation_line = next(
+        (line for line in out.splitlines() if "done" in line.lower()), None
+    )
+    assert confirmation_line is not None, "No confirmation line with 'done' found"
+    assert "1" in confirmation_line, "Task ID missing from confirmation line"
+    assert "Deploy app" in confirmation_line, "Task title missing from confirmation line"
 
 
 def test_cli_complete_persists_status(store):

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -151,6 +151,7 @@ def test_cli_complete_prints_confirmation(store, capsys):
     out = capsys.readouterr().out
     assert "Completed" in out
     assert "Deploy app" in out
+    assert "done" in out.lower()
 
 
 def test_cli_complete_persists_status(store):


### PR DESCRIPTION
This scenario validates same-session update refresh through the PR Rocket helper tools.