### PR TITLE
Include saved wording in add confirmation

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -28,7 +28,7 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
     task = manager.add_task(args.title, description=args.description or "")
-    print(f"Added task [{task.id}]: {task.title} — saved.")
+    print(f"Added task [{task.id}]: {task.title} — saved successfully.")
 
 
 def cmd_complete(args: argparse.Namespace, manager) -> None:

--- a/task_cli.py
+++ b/task_cli.py
@@ -28,7 +28,7 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
     task = manager.add_task(args.title, description=args.description or "")
-    print(f"Added task [{task.id}]: {task.title} — saved successfully.")
+    print(f"Added task [{task.id}]: {task.title} - saved successfully.")
 
 
 def cmd_complete(args: argparse.Namespace, manager) -> None:

--- a/task_cli.py
+++ b/task_cli.py
@@ -28,7 +28,7 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
     task = manager.add_task(args.title, description=args.description or "")
-    print(f"Added task [{task.id}]: {task.title}")
+    print(f"Added task [{task.id}]: {task.title} — saved.")
 
 
 def cmd_complete(args: argparse.Namespace, manager) -> None:

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -84,7 +84,7 @@ def test_cli_add_prints_confirmation(store, capsys):
     out = capsys.readouterr().out
     assert "Fix bug" in out
     assert "Added" in out
-    assert "saved" in out.lower()
+    assert "saved successfully" in out.lower()
 
 
 def test_cli_add_persists_task(store):

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -84,6 +84,7 @@ def test_cli_add_prints_confirmation(store, capsys):
     out = capsys.readouterr().out
     assert "Fix bug" in out
     assert "Added" in out
+    assert "saved" in out.lower()
 
 
 def test_cli_add_persists_task(store):


### PR DESCRIPTION
This scenario validates the short helper-wrapper commands for PR Rocket structured outputs.