### PR TITLE
feat: add slugify_title helper

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -4,9 +4,15 @@ import re
 
 
 def slugify_title(text: str) -> str:
-    """Convert a title string to a URL-friendly slug."""
+    """Convert a title string to a URL-friendly slug.
+
+    Lowercases the text, then collapses underscores and any sequence of
+    repeated punctuation/whitespace into a single hyphen.
+    """
     text = text.lower()
-    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"[_\s]+", "-", text)       # collapse underscores and whitespace
+    text = re.sub(r"[^a-z0-9-]+", "-", text)  # replace remaining non-alphanumeric with hyphen
+    text = re.sub(r"-+", "-", text)            # collapse repeated hyphens
     return text.strip("-")
 
 

--- a/hello.py
+++ b/hello.py
@@ -1,5 +1,14 @@
 """A simple module for e2e testing PR Rocket."""
 
+import re
+
+
+def slugify_title(text: str) -> str:
+    """Convert a title string to a URL-friendly slug."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
 
 def greet(name: str) -> str:
     """Return a greeting."""

--- a/test_hello.py
+++ b/test_hello.py
@@ -17,3 +17,8 @@ def test_subtract():
 
 def test_slugify_title():
     assert slugify_title("Hello, World!") == "hello-world"
+    assert slugify_title("hello_world") == "hello-world"
+    assert slugify_title("hello___world") == "hello-world"
+    assert slugify_title("hello...world") == "hello-world"
+    assert slugify_title("hello_-_world") == "hello-world"
+    assert slugify_title("  leading and trailing  ") == "leading-and-trailing"

--- a/test_hello.py
+++ b/test_hello.py
@@ -1,6 +1,6 @@
 """Tests for hello.py."""
 
-from hello import add, greet, subtract
+from hello import add, greet, slugify_title, subtract
 
 
 def test_greet():
@@ -13,3 +13,7 @@ def test_add():
 
 def test_subtract():
     assert subtract(7, 4) == 3
+
+
+def test_slugify_title():
+    assert slugify_title("Hello, World!") == "hello-world"


### PR DESCRIPTION
Adds `slugify_title(text: str) -> str` to `hello.py` — a URL-friendly slug helper with the following behavior:

1. Lowercases the input
2. Collapses underscores and whitespace sequences into a single hyphen
3. Replaces remaining non-alphanumeric characters (including repeated punctuation) with a hyphen
4. Deduplicates consecutive hyphens into a single hyphen
5. Strips leading and trailing hyphens

| | Finding | Location |
|---|---------|----------|
| 🟢 | Underscores and repeated punctuation correctly collapsed to single hyphen | `hello.py:13-15` |
| 🟢 | Full test coverage including edge cases (leading/trailing spaces, mixed `_-_`, repeated dots) | `test_hello.py:18-24` |