### PR TITLE
docs: add comment-burst metadata test bullet for PR Rocket e2e freshness coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo exists solely for e2e testing. PRs opened here exercise the PR Rocket 
 - Open a PR with merge conflicts → verify `fix_conflicts` feature
 - Use `/rocket` commands in PR comments
 - Test the control panel toggle flow using both slash commands and inline status updates
+- Exercise comment-burst handling on docs-only PR metadata updates
 
 ## Build Exercise
 


### PR DESCRIPTION
Adds a comment-burst metadata test bullet to the README for PR Rocket e2e freshness coverage.

This docs-only change updates the README to include a bullet covering comment-burst metadata scenarios, ensuring PR Rocket's end-to-end test suite has freshness coverage for that case.