### PR TITLE
feat: normalize_username strips punctuation and uses dashes for whitespace

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -17,8 +17,10 @@ def subtract(a: int, b: int) -> int:
 
 
 def normalize_username(username: str) -> str:
-    """Return a normalized username: stripped, lowercased, with collapsed whitespace."""
-    return " ".join(username.split()).lower()
+    """Return a normalized username: stripped, punctuation removed, lowercased, internal whitespace replaced with dashes."""
+    import re
+    cleaned = re.sub(r"[^\w\s]", "", username)
+    return re.sub(r"\s+", "-", cleaned.strip()).lower()
 
 
 if __name__ == "__main__":

--- a/hello.py
+++ b/hello.py
@@ -16,5 +16,10 @@ def subtract(a: int, b: int) -> int:
     return a - b
 
 
+def normalize_username(username: str) -> str:
+    """Return a normalized username: stripped, lowercased, with collapsed whitespace."""
+    return " ".join(username.split()).lower()
+
+
 if __name__ == "__main__":
     print(greet("world"))

--- a/test_hello.py
+++ b/test_hello.py
@@ -13,3 +13,15 @@ def test_add():
 
 def test_subtract():
     assert subtract(7, 4) == 3
+
+
+def test_normalize_username_basic():
+    from hello import normalize_username
+
+    assert normalize_username("  Alice Example  ") == "alice example"
+
+
+def test_normalize_username_internal_spacing():
+    from hello import normalize_username
+
+    assert normalize_username("Bob   Smith") == "bob smith"

--- a/test_hello.py
+++ b/test_hello.py
@@ -16,8 +16,16 @@ def test_subtract():
 
 
 def test_normalize_username_basic():
-    assert normalize_username("  Alice Example  ") == "alice example"
+    assert normalize_username(" Alice Example! ") == "alice-example"
 
 
 def test_normalize_username_internal_spacing():
-    assert normalize_username("Bob   Smith") == "bob smith"
+    assert normalize_username("Bob   Smith") == "bob-smith"
+
+
+def test_normalize_username_punctuation():
+    assert normalize_username(" Alice Example! ") == "alice-example"
+
+
+def test_normalize_username_no_trailing_dash():
+    assert normalize_username("Alice!") == "alice"

--- a/test_hello.py
+++ b/test_hello.py
@@ -1,6 +1,6 @@
 """Tests for hello.py."""
 
-from hello import add, greet, subtract
+from hello import add, greet, normalize_username, subtract
 
 
 def test_greet():
@@ -16,12 +16,8 @@ def test_subtract():
 
 
 def test_normalize_username_basic():
-    from hello import normalize_username
-
     assert normalize_username("  Alice Example  ") == "alice example"
 
 
 def test_normalize_username_internal_spacing():
-    from hello import normalize_username
-
     assert normalize_username("Bob   Smith") == "bob smith"


### PR DESCRIPTION
Implements the updated `normalize_username` helper: strips leading/trailing whitespace, removes punctuation, collapses internal whitespace to single dashes, and lowercases — so `' Alice Example! '` → `'alice-example'`.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `normalize_username` strips punctuation and uses dashes as requested | `hello.py:19` |
| 🟢 | Tests updated and two new edge cases added (`punctuation`, `no_trailing_dash`) | `test_hello.py:18` |

<details>
<summary>Implementation</summary>

```python
def normalize_username(username: str) -> str:
    import re
    cleaned = re.sub(r"[^\w\s]", "", username)
    return re.sub(r"\s+", "-", cleaned.strip()).lower()
```
</details>