### PR TITLE
Normalize and validate task titles; add normalize_username utility

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -16,5 +16,10 @@ def subtract(a: int, b: int) -> int:
     return a - b
 
 
+def normalize_username(name: str) -> str:
+    """Return *name* lowercased with leading/trailing spaces stripped and internal runs collapsed."""
+    return " ".join(name.split()).lower()
+
+
 if __name__ == "__main__":
     print(greet("world"))

--- a/task_cli.py
+++ b/task_cli.py
@@ -27,7 +27,11 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
-    task = manager.add_task(args.title, description=args.description or "")
+    try:
+        task = manager.add_task(args.title, description=args.description or "")
+    except ValueError:
+        print("Error: task title must not be blank.")
+        return
     print(f"Added task [{task.id}]: {task.title}")
 
 

--- a/task_manager.py
+++ b/task_manager.py
@@ -37,6 +37,9 @@ class TaskManager:
 
     def add_task(self, title: str, description: str = "") -> Task:
         """Create and store a new task, returning it."""
+        title = title.strip()
+        if not title:
+            raise ValueError("Task title must not be blank.")
         task = Task(id=self._next_id, title=title, description=description)
         self._tasks[self._next_id] = task
         self._next_id += 1

--- a/test_hello.py
+++ b/test_hello.py
@@ -13,3 +13,15 @@ def test_add():
 
 def test_subtract():
     assert subtract(7, 4) == 3
+
+
+def test_normalize_username_basic():
+    from hello import normalize_username
+
+    assert normalize_username("  Alice Example  ") == "alice example"
+
+
+def test_normalize_username_internal_spacing():
+    from hello import normalize_username
+
+    assert normalize_username("Bob   Smith") == "bob smith"

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -99,6 +99,22 @@ def test_cli_add_with_description(store):
     assert task.description == "Check docs"
 
 
+def test_cli_add_trims_title_before_persisting(store):
+    main(["--file", str(store), "add", "  Research  "])
+    loaded = load(store)
+    task = loaded.list_tasks()[0]
+    assert task.title == "Research"
+
+
+def test_cli_add_blank_title_prints_error(store, capsys):
+    main(["--file", str(store), "add", "   "])
+    out = capsys.readouterr().out
+    assert "title" in out.lower()
+    assert "blank" in out.lower() or "empty" in out.lower()
+    loaded = load(store)
+    assert loaded.list_tasks() == []
+
+
 # ---------------------------------------------------------------------------
 # CLI — list
 # ---------------------------------------------------------------------------

--- a/test_task_manager.py
+++ b/test_task_manager.py
@@ -34,6 +34,16 @@ def test_add_task_stores_description(manager):
     assert task.description == "Cover all edge cases"
 
 
+def test_add_task_trims_title_whitespace(manager):
+    task = manager.add_task("  Write tests  ")
+    assert task.title == "Write tests"
+
+
+def test_add_task_rejects_blank_title(manager):
+    with pytest.raises(ValueError):
+        manager.add_task("   ")
+
+
 # ---------------------------------------------------------------------------
 # get_task
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Strip leading and trailing whitespace from task titles before storing them, so accidental spaces do not leak into the task list
- Reject blank (whitespace-only) task titles with a `ValueError` in `TaskManager.add_task`; the CLI catches it and prints a user-friendly error instead of creating an unusable task
- Add `normalize_username` to `hello.py`: lowercases a name and collapses internal whitespace runs into single spaces

## Why
The CLI previously accepted whitespace-only titles and preserved leading/trailing spaces in normal titles, making the task list noisier than it should be. The `normalize_username` utility provides consistent username formatting for future use.

## Testing
- `pytest -q test_task_manager.py test_task_cli.py`

## Notes
I only want the durable behavior reflected here. Transient bot activity or review chatter should stay out of the PR body.