### PR TITLE
Trim task titles on add and reject whitespace-only titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo exists solely for e2e testing. PRs opened here exercise the PR Rocket 
 
 ## Build Exercise
 
-We are progressively turning this demo into a tiny task app with PR Rocket.
+We are progressively turning this demo into a tiny task-tracking app with PR Rocket.
 Step 1 focuses on a small in-memory task manager API and tests.
 Step 2 adds a small CLI and JSON persistence on top of that task manager.
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+
+### Title handling
+
+- Titles are automatically trimmed of leading and trailing whitespace on add.
+- Whitespace-only titles (e.g. `"   "`) are rejected with an error.

--- a/task_manager.py
+++ b/task_manager.py
@@ -36,7 +36,14 @@ class TaskManager:
         self._next_id: int = 1
 
     def add_task(self, title: str, description: str = "") -> Task:
-        """Create and store a new task, returning it."""
+        """Create and store a new task, returning it.
+
+        The title is stripped of leading/trailing whitespace before storage.
+        Raises ValueError if the stripped title is empty.
+        """
+        title = title.strip()
+        if not title:
+            raise ValueError("Task title must not be empty or whitespace-only.")
         task = Task(id=self._next_id, title=title, description=description)
         self._tasks[self._next_id] = task
         self._next_id += 1

--- a/test_task_manager.py
+++ b/test_task_manager.py
@@ -146,3 +146,23 @@ def test_delete_task_only_removes_target(manager):
     assert manager.get_task(t1.id) is t1
     with pytest.raises(TaskNotFoundError):
         manager.get_task(t2.id)
+
+
+# ---------------------------------------------------------------------------
+# title trimming and whitespace rejection
+# ---------------------------------------------------------------------------
+
+
+def test_add_task_trims_title(manager):
+    task = manager.add_task("  Buy milk  ")
+    assert task.title == "Buy milk"
+
+
+def test_add_task_rejects_whitespace_only_title(manager):
+    with pytest.raises(ValueError):
+        manager.add_task("   ")
+
+
+def test_add_task_rejects_empty_title(manager):
+    with pytest.raises(ValueError):
+        manager.add_task("")


### PR DESCRIPTION
## Summary
- `add_task` now strips leading/trailing whitespace from titles before storing
- `add_task` raises `ValueError` for empty or whitespace-only titles
- README documents this behavior under a new "Title handling" section

## Why
The README should stay accurate as the demo evolves. The validation logic was missing from `task_manager.py`, so both the implementation and its documentation were added together.

## Testing
- 3 new unit tests added to `test_task_manager.py`: trim, whitespace-only rejection, empty rejection
- All 38 tests pass

## Notes
Please keep this body concise if it changes.