### PR TITLE
fix: strip whitespace from greet() name parameter

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -2,8 +2,8 @@
 
 
 def greet(name: str) -> str:
-    """Return a greeting."""
-    return f"Hi there, {name}!"
+    """Return a greeting, stripping leading/trailing whitespace from name."""
+    return f"Hi there, {name.strip()}!"
 
 
 def add(a: int, b: int) -> int:

--- a/test_hello.py
+++ b/test_hello.py
@@ -7,6 +7,10 @@ def test_greet():
     assert greet("world") == "Hi there, world!"
 
 
+def test_greet_trims_name_whitespace():
+    assert greet("  world  ") == "Hi there, world!"
+
+
 def test_add():
     assert add(2, 3) == 5
 


### PR DESCRIPTION
## Summary
- `greet()` in `hello.py` now strips leading/trailing whitespace from the `name` parameter before interpolating it into the greeting string.

## Why
The PR includes a new test (`test_greet_trims_name_whitespace`) asserting that `greet("  world  ") == "Hi there, world!"`. The original implementation passed the name through unmodified, causing the test to fail.

## Changes
- `hello.py`: added `.strip()` call on `name` in `greet()`, updated docstring to reflect the trimming behaviour.

## Testing
- All 4 tests pass: `test_greet`, `test_greet_trims_name_whitespace`, `test_add`, `test_subtract`.