### PR TITLE
fix: strip whitespace from name in greet()

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -3,7 +3,7 @@
 
 def greet(name: str) -> str:
     """Return a greeting."""
-    return f"Hi there, {name}!"
+    return f"Hi there, {name.strip()}!"
 
 
 def add(a: int, b: int) -> int:

--- a/test_hello.py
+++ b/test_hello.py
@@ -7,6 +7,10 @@ def test_greet():
     assert greet("world") == "Hi there, world!"
 
 
+def test_greet_trims_name_whitespace():
+    assert greet("  world  ") == "Hi there, world!"
+
+
 def test_add():
     assert add(2, 3) == 5
 


### PR DESCRIPTION
## Summary
- Add test asserting `greet()` trims leading/trailing whitespace from the name argument
- Fix `greet()` in `hello.py` to call `.strip()` on the input before building the greeting string

## Why
- The greeting should normalise whitespace so `greet("  world  ")` returns `"Hi there, world!"` rather than preserving raw padding

## Testing
- `python -m pytest test_hello.py -v` — all 4 tests pass