### PR TITLE
greet: trim leading/trailing whitespace from name

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -3,7 +3,7 @@
 
 def greet(name: str) -> str:
     """Return a greeting."""
-    return f"Hi there, {name}!"
+    return f"Hi there, {name.strip()}!"
 
 
 def add(a: int, b: int) -> int:

--- a/test_hello.py
+++ b/test_hello.py
@@ -7,6 +7,10 @@ def test_greet():
     assert greet("world") == "Hi there, world!"
 
 
+def test_greet_trims_surrounding_whitespace():
+    assert greet("  world  ") == "Hi there, world!"
+
+
 def test_add():
     assert add(2, 3) == 5
 


### PR DESCRIPTION
## Summary
- `greet()` now strips leading and trailing whitespace from the name before formatting the greeting
- Regression test `test_greet_trims_surrounding_whitespace` confirms the fix

## Why
- `greet("  world  ")` previously returned `"Hi there,   world  !"` instead of `"Hi there, world!"`

## Changes
- `hello.py`: `name.strip()` applied before string interpolation

## Testing
- `pytest -q` — 39 passed