### PR TITLE
fix: greet() falls back to 'world' for blank or whitespace-only names

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -2,7 +2,9 @@
 
 
 def greet(name: str) -> str:
-    """Return a greeting."""
+    """Return a greeting, falling back to 'world' for blank or whitespace-only names."""
+    if not name or not name.strip():
+        name = "world"
     return f"Hi there, {name}!"
 
 

--- a/test_hello.py
+++ b/test_hello.py
@@ -7,6 +7,10 @@ def test_greet():
     assert greet("world") == "Hi there, world!"
 
 
+def test_greet_uses_fallback_for_blank_name():
+    assert greet("   ") == "Hi there, world!"
+
+
 def test_add():
     assert add(2, 3) == 5
 


### PR DESCRIPTION
## Summary
- `greet()` now falls back to `"world"` when the provided name is blank or whitespace-only
- Added regression test `test_greet_uses_fallback_for_blank_name` to prevent future regressions

## Why
- Passing an empty string or whitespace-only string produced an awkward `"Hi there,  !"` greeting instead of a sensible default

## Changes
- `hello.py`: guard in `greet()` — `if not name or not name.strip(): name = "world"`
- `test_hello.py`: regression test asserting `greet("   ") == "Hi there, world!"`

## Testing
```
pytest test_hello.py -v   # 4 passed
```