### PR TITLE
test: cover trimmed greeting names

### DIFF
--- a/test_hello.py
+++ b/test_hello.py
@@ -7,6 +7,10 @@ def test_greet():
     assert greet("world") == "Hi there, world!"
 
 
+def test_greet_strips_whitespace():
+    assert greet("  Ada  ") == "Hi there, Ada!"
+
+
 def test_add():
     assert add(2, 3) == 5
 


### PR DESCRIPTION
Adds a failing regression test showing `greet()` should trim surrounding whitespace before formatting the greeting.

This PR is for PR Rocket run-brief latency testing.