### PR TITLE
Exercise multi-issue CLI normalization lifecycle

### DIFF
--- a/task_cli.py
+++ b/task_cli.py
@@ -75,6 +75,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_list = sub.add_parser("list", help="List tasks")
     p_list.add_argument(
         "--status",
+        type=str.lower,
         choices=[s.value for s in TaskStatus],
         help="Filter by status",
     )

--- a/task_cli.py
+++ b/task_cli.py
@@ -27,7 +27,7 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
-    task = manager.add_task(args.title.strip(), description=args.description or "")
+    task = manager.add_task(args.title.strip(), description=(args.description or "").strip())
     print(f"Added task [{task.id}]: {task.title}")
 
 

--- a/task_cli.py
+++ b/task_cli.py
@@ -27,7 +27,7 @@ def cmd_list(args: argparse.Namespace, manager) -> None:
 
 def cmd_add(args: argparse.Namespace, manager) -> None:
     """Add a new task."""
-    task = manager.add_task(args.title, description=args.description or "")
+    task = manager.add_task(args.title.strip(), description=args.description or "")
     print(f"Added task [{task.id}]: {task.title}")
 
 

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -92,6 +92,15 @@ def test_cli_add_persists_task(store):
     assert any(t.title == "Persisted task" for t in loaded.list_tasks())
 
 
+def test_cli_add_trims_title_whitespace(store, capsys):
+    main(["--file", str(store), "add", "  Trim me  "])
+    out = capsys.readouterr().out
+    loaded = load(store)
+
+    assert "Added task [1]: Trim me" in out
+    assert loaded.list_tasks()[0].title == "Trim me"
+
+
 def test_cli_add_with_description(store):
     main(["--file", str(store), "add", "Research", "--description", "Check docs"])
     loaded = load(store)

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -108,6 +108,13 @@ def test_cli_add_with_description(store):
     assert task.description == "Check docs"
 
 
+def test_cli_add_trims_description_whitespace(store):
+    main(["--file", str(store), "add", "Research", "--description", "  Check docs  "])
+    loaded = load(store)
+
+    assert loaded.list_tasks()[0].description == "Check docs"
+
+
 # ---------------------------------------------------------------------------
 # CLI — list
 # ---------------------------------------------------------------------------

--- a/test_task_cli.py
+++ b/test_task_cli.py
@@ -140,6 +140,17 @@ def test_cli_list_filter_done(store, capsys):
     assert "Pending task" not in out
 
 
+def test_cli_list_filter_status_is_case_insensitive(store, capsys):
+    main(["--file", str(store), "add", "Pending task"])
+    main(["--file", str(store), "add", "Done task"])
+    main(["--file", str(store), "complete", "2"])
+    capsys.readouterr()  # discard setup output
+    main(["--file", str(store), "list", "--status", "DONE"])
+    out = capsys.readouterr().out
+    assert "Done task" in out
+    assert "Pending task" not in out
+
+
 # ---------------------------------------------------------------------------
 # CLI — complete
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the first regression test in a multi-issue PR Rocket lifecycle scenario. This initial commit covers uppercase task status filters such as `DONE`.

## Test plan

- `pytest -q` currently fails on the new status normalization test by design.

## PR Rocket expectations

- First pass should fix status normalization.
- Later commits will add separate CLI normalization failures on the same PR so we can verify event freshness, run briefs, self-push suppression, and activity/admin metrics over the life of one PR.