### PR TITLE
feat: add task_helpers module with group_by_status and filter_by_assignee

### DIFF
--- a/task_helpers.py
+++ b/task_helpers.py
@@ -1,0 +1,17 @@
+"""Helpers for working with task lists."""
+
+from typing import Iterable
+
+
+def group_by_status(tasks: Iterable[dict]) -> dict[str, list[dict]]:
+    """Group tasks by their status field. Tasks without a status go to 'unknown'."""
+    groups: dict[str, list[dict]] = {}
+    for task in tasks:
+        status = task.get("status", "unknown")
+        groups.setdefault(status, []).append(task)
+    return groups
+
+
+def filter_by_assignee(tasks: Iterable[dict], assignee: str) -> list[dict]:
+    """Return tasks whose 'assignee' field matches the given login."""
+    return [t for t in tasks if t.get("assignee") == assignee]

--- a/test_task_helpers.py
+++ b/test_task_helpers.py
@@ -1,0 +1,30 @@
+from task_helpers import filter_by_assignee, group_by_status
+
+
+def test_group_by_status_groups_correctly():
+    tasks = [
+        {"id": 1, "status": "open"},
+        {"id": 2, "status": "done"},
+        {"id": 3, "status": "open"},
+    ]
+    groups = group_by_status(tasks)
+    assert {t["id"] for t in groups["open"]} == {1, 3}
+    assert {t["id"] for t in groups["done"]} == {2}
+
+
+def test_group_by_status_handles_missing():
+    groups = group_by_status([{"id": 1}])
+    assert groups["unknown"] == [{"id": 1}]
+
+
+def test_filter_by_assignee():
+    tasks = [
+        {"id": 1, "assignee": "alice"},
+        {"id": 2, "assignee": "bob"},
+        {"id": 3, "assignee": "alice"},
+    ]
+    assert {t["id"] for t in filter_by_assignee(tasks, "alice")} == {1, 3}
+
+
+def test_filter_by_assignee_no_matches():
+    assert filter_by_assignee([{"id": 1, "assignee": "alice"}], "carol") == []


### PR DESCRIPTION
Adds a new `task_helpers.py` module with two utility functions for working with task lists, along with full test coverage in `test_task_helpers.py`.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Full test coverage: 4 tests covering normal and edge cases | `test_task_helpers.py` |
| 🟢 | Proper use of type hints with `Iterable[dict]` and `dict[str, list[dict]]` | `task_helpers.py:6,15` |
| 🟢 | Docstrings on all public functions | `task_helpers.py:7,16` |

## Changes

- **`task_helpers.py`** — New module with:
  - `group_by_status(tasks)`: groups an iterable of task dicts by their `status` field; tasks missing a status go to `"unknown"`
  - `filter_by_assignee(tasks, assignee)`: returns tasks whose `assignee` field matches the given login
- **`test_task_helpers.py`** — 4 pytest tests covering grouping, missing-status fallback, assignee filtering, and no-match cases

## Testing

All 4 tests pass:
```
test_task_helpers.py::test_group_by_status_groups_correctly PASSED
test_task_helpers.py::test_group_by_status_handles_missing PASSED
test_task_helpers.py::test_filter_by_assignee PASSED
test_task_helpers.py::test_filter_by_assignee_no_matches PASSED
```