### PR TITLE
docs: add Contributing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,19 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+
+## Contributing
+
+Pull requests are welcome. To get started:
+
+1. Fork the repository
+2. Create a feature branch off `main`
+3. Make your changes with tests
+4. Open a PR — PR Rocket will automatically rewrite your PR title and body if you leave them blank
+
+### Style
+
+- Python 3.12+
+- Follow PEP 8
+- Tests live next to the modules they test (e.g. `test_hello.py` for `hello.py`)
+- Keep changes focused — one feature per PR


### PR DESCRIPTION
Adds a **Contributing** section to the README with onboarding steps for new contributors.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Contributing section covers fork, branch, test, and PR workflow | `README.md:46-58` |
| ℹ️ | Python 3.12+ requirement now documented in style guidelines | `README.md:52` |

### What changed
- Added `## Contributing` section with step-by-step PR workflow
- Added `### Style` subsection documenting Python 3.12+, PEP 8, test placement convention, and focus policy

### Testing notes
No code changes — docs only. No tests required.