### PR TITLE
docs: add versioning policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+
+
+## Versioning
+
+We follow SemVer. Bump MINOR for new features, PATCH for fixes.


### PR DESCRIPTION
Adds a short versioning policy section to the README documenting that the project follows SemVer with MINOR bumps for new features and PATCH bumps for fixes.

| | Finding | Location |
|---|---------|----------|
| ℹ️ | Versioning section added to docs only; no code changes included | `README.md:46-49` |

### What changed
- `README.md`: New `## Versioning` section at the end of the file stating adherence to SemVer conventions.

### Testing notes
Documentation-only change; no tests required.