### PR TITLE
docs: add versioning policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+
+
+## Versioning
+
+We follow SemVer. Bump MINOR for new features, PATCH for fixes.


### PR DESCRIPTION
Adds a `## Versioning` section to the README documenting the project's SemVer policy.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Versioning policy documented | `README.md:46-50` |

## What changed
- Added `## Versioning` section to `README.md` stating the project follows SemVer (MINOR for features, PATCH for fixes).

## Why
Documenting the versioning policy makes it clear to contributors how to bump the version when making changes.

## Testing notes
No code changes — docs only. No tests required.