### PR TITLE
feat: add string_utils module with reverse and is_palindrome helpers

### DIFF
--- a/string_utils.py
+++ b/string_utils.py
@@ -1,0 +1,12 @@
+"""String manipulation utilities."""
+
+
+def reverse(s: str) -> str:
+    """Return the reversed string."""
+    return s[::-1]
+
+
+def is_palindrome(s: str) -> bool:
+    """Check whether s reads the same forwards and backwards."""
+    cleaned = s.lower().replace(' ', '')
+    return cleaned == cleaned[::-1]

--- a/test_string_utils.py
+++ b/test_string_utils.py
@@ -1,0 +1,12 @@
+from string_utils import reverse, is_palindrome
+
+
+def test_reverse():
+    assert reverse("hello") == "olleh"
+    assert reverse("") == ""
+
+
+def test_is_palindrome():
+    assert is_palindrome("racecar")
+    assert is_palindrome("A man a plan a canal Panama")
+    assert not is_palindrome("hello")


### PR DESCRIPTION
Adds a new `string_utils` module with two string helper functions and corresponding unit tests.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Type hints and docstrings on all public functions | `string_utils.py:4-11` |
| 🟢 | Tests cover empty string edge case for `reverse` | `test_string_utils.py:6` |
| ℹ️ | `is_palindrome` strips only spaces; punctuation (e.g. commas) is not stripped | `string_utils.py:11` |

## What changed
- **`string_utils.py`** — new module with:
  - `reverse(s)` — returns the reversed string using slice notation
  - `is_palindrome(s)` — case-insensitive palindrome check (strips spaces)
- **`test_string_utils.py`** — unit tests for both functions

## Testing
```
pytest test_string_utils.py -v
```
All 2 tests pass.

## Breaking changes
None — new module only.