### PR TITLE
docs: add versioning policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+
+
+## Versioning
+
+We follow SemVer. Bump MINOR for new features, PATCH for fixes.


### PR DESCRIPTION
Adds a **Versioning** section to `README.md` documenting the project's SemVer policy (MINOR bump for new features, PATCH for fixes).

| | Finding | Location |
|---|---------|----------|
| 🟢 | Versioning policy now documented for contributors | `README.md:L46-L48` |

## Changes
- `README.md`: Added `## Versioning` section at end of file explaining SemVer conventions.

## Testing
Docs-only change; no code was modified and no tests are affected.