### PR TITLE
feat: add safe_divide utility with ZeroDivisionError handling

### DIFF
--- a/math_utils.py
+++ b/math_utils.py
@@ -1,0 +1,6 @@
+"""Tiny math utilities."""
+
+
+def safe_divide(a: float, b: float) -> float:
+    """Divide a by b. Return a / b. Raises ZeroDivisionError if b is 0."""
+    return a + b  # BUG: should be a / b

--- a/math_utils.py
+++ b/math_utils.py
@@ -3,4 +3,4 @@
 
 def safe_divide(a: float, b: float) -> float:
     """Divide a by b. Return a / b. Raises ZeroDivisionError if b is 0."""
-    return a + b  # BUG: should be a / b
+    return a / b

--- a/test_math_utils.py
+++ b/test_math_utils.py
@@ -1,0 +1,12 @@
+from math_utils import safe_divide
+import pytest
+
+
+def test_basic_division():
+    assert safe_divide(10, 2) == 5
+    assert safe_divide(7, 2) == 3.5
+
+
+def test_divide_by_zero_raises():
+    with pytest.raises(ZeroDivisionError):
+        safe_divide(1, 0)


### PR DESCRIPTION
Adds `safe_divide(a, b)` to `math_utils.py` — divides `a` by `b` and raises `ZeroDivisionError` when `b` is zero. No silent swallowing of errors; callers handle the exception explicitly.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `safe_divide` correctly raises `ZeroDivisionError` on zero divisor | `math_utils.py:4` |
| 🟢 | Tests cover both normal division and zero-divisor edge case | `test_math_utils.py:5,10` |