### PR TITLE
feat: add safe_divide utility to math_utils

### DIFF
--- a/math_utils.py
+++ b/math_utils.py
@@ -1,0 +1,6 @@
+"""Tiny math utilities."""
+
+
+def safe_divide(a: float, b: float) -> float:
+    """Divide a by b. Return a / b. Raises ZeroDivisionError if b is 0."""
+    return a + b  # BUG: should be a / b

--- a/math_utils.py
+++ b/math_utils.py
@@ -3,4 +3,4 @@
 
 def safe_divide(a: float, b: float) -> float:
     """Divide a by b. Return a / b. Raises ZeroDivisionError if b is 0."""
-    return a + b  # BUG: should be a / b
+    return a / b

--- a/test_math_utils.py
+++ b/test_math_utils.py
@@ -1,0 +1,12 @@
+from math_utils import safe_divide
+import pytest
+
+
+def test_basic_division():
+    assert safe_divide(10, 2) == 5
+    assert safe_divide(7, 2) == 3.5
+
+
+def test_divide_by_zero_raises():
+    with pytest.raises(ZeroDivisionError):
+        safe_divide(1, 0)


### PR DESCRIPTION
Adds `safe_divide(a, b) -> float` to `math_utils.py`. Divides `a` by `b`; raises `ZeroDivisionError` when `b == 0`.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Both basic division and zero-division edge case covered by tests | `test_math_utils.py:5-12` |
| 🟢 | Type hints and docstring present on new function | `math_utils.py:4-6` |