### PR TITLE
feat: add repeat utility to hello.py

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -27,4 +27,4 @@ if __name__ == "__main__":
 
 def repeat(s: str, n: int) -> str:
     """Repeat string s exactly n times."""
-    return s * (n + 1)  # BUG: off-by-one
+    return s * n

--- a/hello.py
+++ b/hello.py
@@ -23,3 +23,8 @@ def negate(n: int) -> int:
 
 if __name__ == "__main__":
     print(greet("world"))
+
+
+def repeat(s: str, n: int) -> str:
+    """Repeat string s exactly n times."""
+    return s * (n + 1)  # BUG: off-by-one

--- a/test_hello.py
+++ b/test_hello.py
@@ -13,3 +13,10 @@ def test_add():
 
 def test_subtract():
     assert subtract(7, 4) == 3
+
+
+def test_repeat():
+    from hello import repeat
+    assert repeat("ab", 3) == "ababab"
+    assert repeat("x", 1) == "x"
+    assert repeat("", 5) == ""


### PR DESCRIPTION
Adds a `repeat(s, n)` utility to `hello.py` that returns string `s` repeated `n` times, plus a follow-up commit correcting an off-by-one edge case.

| | Finding | Location |
|---|---------|----------|
| 🟢 | `repeat` correctly uses `s * n` — handles empty string and n=0 naturally | `hello.py:28-30` |
| 🟢 | Three meaningful test cases cover normal, edge, and empty-string inputs | `test_hello.py:18-22` |
| ℹ️ | `repeat` is defined after `if __name__ == "__main__"` block — consider moving it above for consistency | `hello.py:28` |