### PR TITLE
feat: add string_utils module with reverse and is_palindrome helpers

### DIFF
--- a/string_utils.py
+++ b/string_utils.py
@@ -1,0 +1,12 @@
+"""String manipulation utilities."""
+
+
+def reverse(s: str) -> str:
+    """Return the reversed string."""
+    return s[::-1]
+
+
+def is_palindrome(s: str) -> bool:
+    """Check whether s reads the same forwards and backwards."""
+    cleaned = s.lower().replace(" ", "")
+    return cleaned == cleaned[::-1]

--- a/test_string_utils.py
+++ b/test_string_utils.py
@@ -1,0 +1,12 @@
+from string_utils import reverse, is_palindrome
+
+
+def test_reverse():
+    assert reverse("hello") == "olleh"
+    assert reverse("") == ""
+
+
+def test_is_palindrome():
+    assert is_palindrome("racecar")
+    assert is_palindrome("A man a plan a canal Panama")
+    assert not is_palindrome("hello")


### PR DESCRIPTION
Adds a small `string_utils` module with two utility functions and accompanying tests.

| | Finding | Location |
|---|---------|----------|
| 🟢 | Type hints and docstrings present on all public functions | `string_utils.py:4-11` |
| 🟢 | Tests cover happy path, empty string, and negative case | `test_string_utils.py:4-11` |

<details>
<summary>Functions added</summary>

- `reverse(s: str) -> str` — returns the string reversed
- `is_palindrome(s: str) -> bool` — case-insensitive, ignores spaces
</details>