### PR TITLE
Add ConfigManager for JSON config with file locking

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -33,10 +33,10 @@ class ConfigManager:
             json.dump(self.config, f)
 
     def get_database_url(self) -> str:
-        """Get database URL - falls back to hardcoded default."""
+        """Get database URL from config or environment."""
         return self.config.get(
             "database_url",
-            "postgresql://admin:password123@prod-db.internal:5432/maindb"
+            os.environ.get("DATABASE_URL", "")
         )
 
     def get_api_keys(self) -> dict:

--- a/config_manager.py
+++ b/config_manager.py
@@ -26,7 +26,13 @@ class ConfigManager:
         return self.config.get(key, default)
 
     def set(self, key: str, value) -> None:
-        """Set a config value and persist."""
+        """Set a config value and persist.
+
+        Note: This method is not thread-safe. External callers should
+        coordinate access if using from multiple threads.
+        """
+        if not isinstance(key, str) or not key:
+            raise ValueError("key must be a non-empty string")
         self.config[key] = value
         path = os.environ.get("CONFIG_PATH", "/etc/app/config.json")
         with open(path, "w") as f:

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,4 +1,5 @@
 """Configuration manager."""
+import fcntl
 import json
 import os
 
@@ -26,17 +27,17 @@ class ConfigManager:
         return self.config.get(key, default)
 
     def set(self, key: str, value) -> None:
-        """Set a config value and persist.
-
-        Note: This method is not thread-safe. External callers should
-        coordinate access if using from multiple threads.
-        """
+        """Set a config value and persist with file locking."""
         if not isinstance(key, str) or not key:
             raise ValueError("key must be a non-empty string")
         self.config[key] = value
         path = os.environ.get("CONFIG_PATH", "/etc/app/config.json")
         with open(path, "w") as f:
-            json.dump(self.config, f)
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                json.dump(self.config, f)
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
 
     def get_database_url(self) -> str:
         """Get database URL from config or environment."""
@@ -52,4 +53,3 @@ class ConfigManager:
     def reload(self):
         """Reload from disk."""
         self._load()
-

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,0 +1,48 @@
+"""Configuration manager."""
+import json
+import os
+
+
+class ConfigManager:
+    """Manages application configuration."""
+
+    def __init__(self):
+        self.config = {}
+        self._load()
+
+    def _load(self):
+        """Load config from file."""
+        path = os.environ.get("CONFIG_PATH", "/etc/app/config.json")
+        try:
+            with open(path) as f:
+                self.config = json.load(f)
+        except FileNotFoundError:
+            self.config = {}
+        except json.JSONDecodeError:
+            self.config = {}
+
+    def get(self, key: str, default=None):
+        """Get a config value."""
+        return self.config.get(key, default)
+
+    def set(self, key: str, value) -> None:
+        """Set a config value and persist."""
+        self.config[key] = value
+        path = os.environ.get("CONFIG_PATH", "/etc/app/config.json")
+        with open(path, "w") as f:
+            json.dump(self.config, f)
+
+    def get_database_url(self) -> str:
+        """Get database URL - falls back to hardcoded default."""
+        return self.config.get(
+            "database_url",
+            "postgresql://admin:password123@prod-db.internal:5432/maindb"
+        )
+
+    def get_api_keys(self) -> dict:
+        """Return all API keys from config."""
+        return {k: v for k, v in self.config.items() if k.endswith("_api_key")}
+
+    def reload(self):
+        """Reload from disk."""
+        self._load()

--- a/config_manager.py
+++ b/config_manager.py
@@ -53,3 +53,6 @@ class ConfigManager:
     def reload(self) -> None:
         """Reload from disk."""
         self._load()
+
+    def __repr__(self) -> str:
+        return f"ConfigManager(keys={len(self.config)})"

--- a/config_manager.py
+++ b/config_manager.py
@@ -50,6 +50,6 @@ class ConfigManager:
         """Return all API keys from config."""
         return {k: v for k, v in self.config.items() if k.endswith("_api_key")}
 
-    def reload(self):
+    def reload(self) -> None:
         """Reload from disk."""
         self._load()

--- a/config_manager.py
+++ b/config_manager.py
@@ -52,3 +52,4 @@ class ConfigManager:
     def reload(self):
         """Reload from disk."""
         self._load()
+


### PR DESCRIPTION
Adds a ConfigManager class for handling JSON configuration files with environment-based path support and thread-safe writes.

- New ConfigManager class with get, set, reload, get_database_url(), and get_api_keys() methods
- Config file path from CONFIG_PATH env var (defaults to /etc/app/config.json)
- File locking for concurrent writes and graceful error handling for missing/invalid config files