### PR TITLE
Add TTLCache for in-memory caching with expiration

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,21 @@
+"""Simple in-memory cache with TTL."""
+import time
+
+class TTLCache:
+    def __init__(self, default_ttl=60):
+        self._store = {}
+        self._ttl = default_ttl
+
+    def get(self, key):
+        entry = self._store.get(key)
+        if entry and time.time() < entry[1]:
+            return entry[0]
+        self._store.pop(key, None)
+        return None
+
+    def set(self, key, value, ttl=None):
+        expires = time.time() + (ttl or self._ttl)
+        self._store[key] = (value, expires)
+
+    def clear(self):
+        self._store.clear()


### PR DESCRIPTION
Add a simple in-memory cache with TTL support.

- Add `TTLCache` class with configurable default TTL (60s)
- Implement `get()` to retrieve values that haven't expired, auto-cleaning expired entries
- Implement `set()` to store values with optional per-key TTL override
- Implement `clear()` to remove all cached entries