### PR TITLE
Add test line to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+# test


### PR DESCRIPTION
Adds a test line to the README for issue triage purposes.

- Added `# test` to end of README.md