### PR TITLE
Add development setup and contributing guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ python task_cli.py --file my_tasks.json list
 ```
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
+
+## Development
+
+```bash
+pip install -r requirements.txt
+python -m pytest
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Submit a pull request


### PR DESCRIPTION
Adds Development and Contributing sections to the README with setup instructions and contribution workflow.

- Add Development section with `pip install` and `pytest` commands for local setup
- Add Contributing section with fork/branch/PR workflow for contributors