### PR TITLE
Add retry utility with exponential backoff

### DIFF
--- a/retry.py
+++ b/retry.py
@@ -1,0 +1,18 @@
+"""Retry utility with exponential backoff."""
+
+import time
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def retry(fn: Callable[[], T], max_attempts: int = 3, base_delay: float = 0.5) -> T:
+    """Retry fn with exponential backoff."""
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except Exception:
+            if attempt == max_attempts - 1:
+                raise
+            time.sleep(base_delay * (2 ** attempt))
+    raise RuntimeError("unreachable")

--- a/test_retry.py
+++ b/test_retry.py
@@ -1,0 +1,23 @@
+"""Tests for retry utility."""
+
+from retry import retry
+
+
+def test_retry_success_first_try():
+    calls = []
+    def fn():
+        calls.append(1)
+        return "ok"
+    assert retry(fn) == "ok"
+    assert len(calls) == 1
+
+
+def test_retry_eventual_success():
+    calls = []
+    def fn():
+        calls.append(1)
+        if len(calls) < 3:
+            raise ValueError("not yet")
+        return "done"
+    assert retry(fn, max_attempts=3, base_delay=0.01) == "done"
+    assert len(calls) == 3


### PR DESCRIPTION
Add a `retry` utility function with exponential backoff for handling transient failures.

- New `retry.py` module with `retry()` function supporting configurable attempts and base delay
- Exponential backoff formula: `base_delay * (2 ** attempt)`
- Reraises the final exception after all attempts are exhausted
- New `test_retry.py` covering success on first try and eventual success after retries