### PR TITLE
Add CLI argument parser module

### DIFF
--- a/argparser.py
+++ b/argparser.py
@@ -1,0 +1,35 @@
+"""Command-line argument parser wrapper."""
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CLIArgs:
+    verbose: bool
+    output: str
+    input_files: list[str]
+
+
+def parse_args(argv: list[str] | None = None) -> CLIArgs:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Process files")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-o", "--output", default="stdout")
+    parser.add_argument("files", nargs="+", help="Input files")
+    
+    args = parser.parse_args(argv)
+    return CLIArgs(verbose=args.verbose, output=args.output, input_files=args.files)
+
+
+def main():
+    args = parse_args()
+    if args.verbose:
+        print(f"Processing {len(args.input_files)} files...")
+    for f in args.input_files:
+        print(f"  → {f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new `argparser.py` module with a wrapper around `argparse` for processing files from the command line.

- Added `CLIArgs` frozen dataclass with `verbose`, `output`, and `input_files` fields
- Implemented `parse_args()` function supporting `-v/--verbose`, `-o/--output`, and positional `files` arguments
- Added `main()` entry point that prints processed files when verbose mode is enabled