### PR TITLE
Add HTTP client wrapper with GET and POST support

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -1,0 +1,40 @@
+"""Minimal HTTP client wrapper."""
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    body: str
+    headers: dict[str, str]
+
+    def json(self) -> Any:
+        return json.loads(self.body)
+
+
+def get(url: str, headers: dict[str, str] | None = None, timeout: int = 30) -> Response:
+    """Perform an HTTP GET request."""
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return Response(
+            status=resp.status,
+            body=resp.read().decode(),
+            headers=dict(resp.headers),
+        )
+
+
+def post(url: str, data: Any, headers: dict[str, str] | None = None, timeout: int = 30) -> Response:
+    """Perform an HTTP POST request with JSON body."""
+    body = json.dumps(data).encode()
+    h = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(url, data=body, headers=h, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return Response(
+            status=resp.status,
+            body=resp.read().decode(),
+            headers=dict(resp.headers),
+        )


### PR DESCRIPTION
Adds a minimal HTTP client wrapper using Python's stdlib `urllib.request`.

- Introduces `Response` dataclass with `status`, `body`, `headers` fields and a `json()` helper method
- Adds `get()` function supporting custom headers and configurable timeout
- Adds `post()` function that serializes data as JSON and sets `Content-Type` header automatically
