### PR TITLE
Add template engine with variable substitution

### DIFF
--- a/template_engine.py
+++ b/template_engine.py
@@ -1,0 +1,18 @@
+"""Minimal template engine."""
+
+import re
+from typing import Any
+
+
+class TemplateError(Exception):
+    pass
+
+
+def render(template: str, context: dict[str, Any]) -> str:
+    """Render template with variable substitution."""
+    def replacer(match):
+        key = match.group(1).strip()
+        if key not in context:
+            raise TemplateError(f"Undefined variable: {key}")
+        return str(context[key])
+    return re.sub(r"\{\{\s*(\w+)\s*\}\}", replacer, template)


### PR DESCRIPTION
Adds a minimal template engine with variable substitution support.

- New `template_engine.py` module with `TemplateError` exception and `render()` function
- `render()` substitutes `{{variable}}` placeholders using a context dictionary
- Raises `TemplateError` if a referenced variable is not in the context