### PR TITLE
Add discount and currency formatting helpers

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -11,3 +11,4 @@ def format_currency(amount: float, currency: str = "USD") -> str:
     symbols = {"USD": "$", "EUR": "\u20ac", "GBP": "\u00a3"}
     symbol = symbols.get(currency, currency + " ")
     return f"{symbol}{amount:.2f}"
+# Updated Tue May  5 01:50:37 CDT 2026

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,13 @@
+"""Helper utilities for the demo project."""
+
+def calculate_discount(price: float, percent: float) -> float:
+    """Apply a percentage discount to a price."""
+    if percent < 0 or percent > 100:
+        raise ValueError("Discount must be between 0 and 100")
+    return price * (1 - percent / 100)
+
+def format_currency(amount: float, currency: str = "USD") -> str:
+    """Format an amount as currency string."""
+    symbols = {"USD": "$", "EUR": "\u20ac", "GBP": "\u00a3"}
+    symbol = symbols.get(currency, currency + " ")
+    return f"{symbol}{amount:.2f}"


### PR DESCRIPTION
Adds a `helpers.py` module with utility functions for demo purposes.

- `calculate_discount(price, percent)` — validates percent is 0–100, raises `ValueError` otherwise, returns discounted price
- `format_currency(amount, currency="USD")` — formats floats with currency symbols for USD (`$`), EUR (`€`), and GBP (`£`); falls back to currency code + space for unknown currencies