### PR TITLE
ACCURATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ python task_cli.py --file my_tasks.json list
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
 x
 trigger-1778046467
+pr-rocket-body-safety-1778114397

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ python task_cli.py --file my_tasks.json list
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
 x
+trigger-1778046467


### PR DESCRIPTION
The diff confirms two trigger strings are appended to the end of README.md. The title ("Append trigger marker") accurately describes the action; the body calls it "a test trigger string" (singular) while the diff adds two — a minor imprecision but doesn't invalidate the claim. No code logic to review; this is a documentation-only change.