### PR TITLE
stuff → "Add smoke marker to README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ python task_cli.py --file my_tasks.json list
 
 Tasks are persisted to `tasks.json` in the working directory by default. Use `--file PATH` to specify a different store.
 x
+- Smoke marker: metadata contract probe


### PR DESCRIPTION
Title "stuff" and body claims ("adds the full task persistence and CLI workflow rewrite", "Reworks storage internals", "Adds richer command handling", "Tightens error semantics") are entirely unsupported by the diff, which only adds one line to README.md.