### PR TITLE
refactor: change complete_task to mark tasks IN_PROGRESS instead of DONE

### DIFF
--- a/task_manager.py
+++ b/task_manager.py
@@ -75,7 +75,7 @@ class TaskManager:
 
     def complete_task(self, task_id: int) -> Task:
         """Mark *task_id* as DONE and return it."""
-        return self.update_task(task_id, status=TaskStatus.DONE)
+        return self.update_task(task_id, status=TaskStatus.IN_PROGRESS)
 
     def delete_task(self, task_id: int) -> None:
         """Remove *task_id* from the store."""


### PR DESCRIPTION
## Summary

**PR claims vs evidence: MISMATCH**

The PR title and body describe a "refactor" with "no behavioral changes," but the diff changes `complete_task()` to set `IN_PROGRESS` instead of `DONE`. This is a functional bug, not a refactor.

**Key issue:** `complete_task()` now marks tasks as `IN_PROGRESS`, which contradicts:
- The method name (`complete_task` should complete tasks)
- The docstring ("Mark *task_id* as DONE")
- The stated intent of "no behavioral changes"

A task marked `IN_PROGRESS` after calling `complete_task()` is an incomplete task — the core behavior has changed.