### PR TITLE
add helpers module with discount and currency utilities

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,15 @@
+"""Helper utilities for the demo project."""
+
+E2E_RUN_ID = "1780335536"
+
+def calculate_discount(price: float, percent: float) -> float:
+    """Apply a percentage discount to a price."""
+    if percent < 0 or percent > 100:
+        raise ValueError("Discount must be between 0 and 100")
+    return price * (1 - percent / 100)
+
+def format_currency(amount: float, currency: str = "USD") -> str:
+    """Format an amount as currency string."""
+    symbols = {"USD": "$", "EUR": "\u20ac", "GBP": "\u00a3"}
+    symbol = symbols.get(currency, currency + " ")
+    return f"{symbol}{amount:.2f}"


### PR DESCRIPTION
Add a new `helpers.py` module with discount and currency formatting utilities.

- Add `calculate_discount(price, percent)` that validates percent is within 0–100
- Add `format_currency(amount, currency="USD")` with USD/EUR/GBP symbol support
- Add `E2E_RUN_ID` constant